### PR TITLE
Disable ES security for Bankdemo IDE and PL/I demos

### DIFF
--- a/tutorial/gettingstarted/eclipse/PLIDemo.md
+++ b/tutorial/gettingstarted/eclipse/PLIDemo.md
@@ -42,6 +42,17 @@ Please see the Micro Focus product documentation for more information.
 9. Be sure to check the active build configuration is 'x64' in the project properties before continuing as this demo is designed to run only in 64-bit mode.
 10.  Ensure the project has been built (either because Auto-build is enabled) or by clicking **Build** on the **Project** menu.
 
+### Disable the default Enterprise Server security configuration
+
+In this release, the Enterprise Server security features are enabled by default. Tutorials that use enterprise server regions, however, assume that Enterprise Server security is not configured. To perform this tutorial without modification, you must disable the default configured Enterprise Server security. See *To Disable the Default Enterprise Server Security Configuration* for more information.
+
+> **Important**: Micro Focus does not recommend disabling Enterprise Server security permanently. If you disable the default Enterprise Server security to facilitate running tutorials then this should be performed on a network isolated machine. Re-enable security as soon as possible after completing the tutorial. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
+
+1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd` (Windows) or `DisableESDefaultSecurity.sh` (UNIX). You will see a series of messages as the script disables default security.
+2. Restart MFDS and ESCWA to pick up the configuration changes. You will now be able to use ESCWA without having to log in.
+3. Restart any running enterprise server region to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
+
+
 ### Configure the BANKDEMO enterprise server for PL/I:
 
 1. In the **Server Explorer** tab, right-click on **BANKDEMO** under **Local**, and click **Open Administration Page**. This opens the **Enterprise Server Common Web Administration** (ESCWA for short)  page outside of Eclipse.
@@ -85,3 +96,5 @@ When you have finished running the CICS demo, you can stop the associated the en
 
 1. In Eclipse, right-click the **BANKDEMO** server in **Server Explorer**, and click **Stop**.
 2. Check the **Output** view for messages that the server has been stopped. A number of messages also appear in the **Enterprise Server Console Daemon** window before it closes down.
+
+> **Note**: You should re-enable Enterprise Server security if you have not already done so. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 

--- a/tutorial/gettingstarted/eclipse/PLIDemo.md
+++ b/tutorial/gettingstarted/eclipse/PLIDemo.md
@@ -48,9 +48,9 @@ In this release, the Enterprise Server security features are enabled by default.
 
 > **Important**: Micro Focus does not recommend disabling Enterprise Server security permanently. If you disable the default Enterprise Server security to facilitate running tutorials then this should be performed on a network isolated machine. Re-enable security as soon as possible after completing the tutorial. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
 
-1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd` (Windows) or `DisableESDefaultSecurity.sh` (UNIX). You will see a series of messages as the script disables default security.
+1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd`. You will see a series of messages as the script disables default security.
 2. Restart MFDS and ESCWA to pick up the configuration changes. You will now be able to use ESCWA without having to log in.
-3. Restart any running enterprise server region to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
+3. Restart any running enterprise server regions to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
 
 
 ### Configure the BANKDEMO enterprise server for PL/I:

--- a/tutorial/gettingstarted/eclipse/README.md
+++ b/tutorial/gettingstarted/eclipse/README.md
@@ -51,6 +51,19 @@ For example, Directory Server is configured, by default, to use port 86. Your mu
 
 We recommend that, if you want remote users to access Enterprise Server functionality through the firewall, you use fixed port values so that you can control access via these.
 
+## Enterprise Server security
+
+In this release, the Enterprise Server security features are enabled by default. Tutorials that use enterprise server regions, however, assume that Enterprise Server security is not configured. To perform this tutorial without modification, you must disable the default configured Enterprise Server security. See *To Disable the Default Enterprise Server Security Configuration* for more information.
+
+### Disable the default Enterprise Server security configuration
+
+> **Important**: Micro Focus does not recommend disabling Enterprise Server security permanently. If you disable the default Enterprise Server security to facilitate running tutorials then this should be performed on a network isolated machine. Re-enable security as soon as possible after completing the tutorial. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
+
+1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd` (Windows) or `DisableESDefaultSecurity.sh` (UNIX). You will see a series of messages as the script disables default security.
+2. Restart MFDS and ESCWA to pick up the configuration changes. You will now be able to use ESCWA without having to log in.
+3. Restart any running enterprise server region to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
+
+
 ## Starting the Eclipse Integrated Development Environment (IDE)
 
 [Back to Top](#overview)
@@ -313,7 +326,7 @@ This turns the data items and the paragraph names you hover over into hyperlinks
 You can use rename refactoring to rename all occurrences of a variable:
 
 1.  Scroll down to line 228 in the file.
-2.  Cclick WS-EXEC-PARM-LL in the editor, right-click it, and click **Refactor \> Rename**.
+2.  Click WS-EXEC-PARM-LL in the editor, right-click it, and click **Refactor \> Rename**.
 
     A pop-up is displayed prompting you to enter a new name for the variable.
     ![](images/2e15eb9d708cff50ce53b2564221fcf8.jpg)
@@ -418,7 +431,8 @@ A much more suitable and less error-prone way to edit BMS files is to use the BM
 1.  Close the BMS text editor.
 2.  In the Application Explorer view, **right-click MBANK10.bms** in the **bms\\cobol** folder of your project, and click **Open With** \> **BMS Paint**.
 
-    ![](images/ad53b86263c5a5de6c2f308fe5433ac3.png)This starts the external Micro Focus BMS Painter.
+    ![](images/ad53b86263c5a5de6c2f308fe5433ac3.png)
+    This starts the external Micro Focus BMS Painter.
 
 3.  In BMS Painter, you can click fields and move them by dragging.
 
@@ -1032,5 +1046,7 @@ You use the same features as previously to debug the application.
 2. Finally, click the **Team Developer** perspective button, ![](images/88f58bfeb3fd128cb2fe55172b59806e.jpg), to switch back to editing your application.
 
 This concludes this set of tutorials that introduce Enterprise Developer.
+
+> **Note**: You should re-enable Enterprise Server security if you have not already done so. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
 
 [Back to Top](#overview)

--- a/tutorial/gettingstarted/eclipse/README.md
+++ b/tutorial/gettingstarted/eclipse/README.md
@@ -59,9 +59,9 @@ In this release, the Enterprise Server security features are enabled by default.
 
 > **Important**: Micro Focus does not recommend disabling Enterprise Server security permanently. If you disable the default Enterprise Server security to facilitate running tutorials then this should be performed on a network isolated machine. Re-enable security as soon as possible after completing the tutorial. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
 
-1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd` (Windows) or `DisableESDefaultSecurity.sh` (UNIX). You will see a series of messages as the script disables default security.
+1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd`. You will see a series of messages as the script disables default security.
 2. Restart MFDS and ESCWA to pick up the configuration changes. You will now be able to use ESCWA without having to log in.
-3. Restart any running enterprise server region to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
+3. Restart any running enterprise server regions to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
 
 
 ## Starting the Eclipse Integrated Development Environment (IDE)

--- a/tutorial/gettingstarted/eclipseux/readme.md
+++ b/tutorial/gettingstarted/eclipseux/readme.md
@@ -52,6 +52,18 @@ For example, Directory Server is configured, by default, to use port 86. Your mu
 
 We recommend that, if you want remote users to access Enterprise Server functionality through the firewall, you use fixed port values so that you can control access via these.
 
+## Enterprise Server security
+
+In this release, the Enterprise Server security features are enabled by default. Tutorials that use enterprise server regions, however, assume that Enterprise Server security is not configured. To perform this tutorial without modification, you must disable the default configured Enterprise Server security. See *To Disable the Default Enterprise Server Security Configuration* for more information.
+
+### Disable the default Enterprise Server security configuration
+
+> **Important**: Micro Focus does not recommend disabling Enterprise Server security permanently. If you disable the default Enterprise Server security to facilitate running tutorials then this should be performed on a network isolated machine. Re-enable security as soon as possible after completing the tutorial. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
+
+1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd` (Windows) or `DisableESDefaultSecurity.sh` (UNIX). You will see a series of messages as the script disables default security.
+2. Restart MFDS and ESCWA to pick up the configuration changes. You will now be able to use ESCWA without having to log in.
+3. Restart any running enterprise server region to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
+
 ## Starting the Eclipse Integrated Development Environment (IDE)
 
 [Back to Top](#overview)
@@ -1027,5 +1039,7 @@ You use the same features as previously to debug the application.
 2. Finally, click the **Team Developer** perspective button ![](images/88f58bfeb3fd128cb2fe55172b59806e.jpg), to switch back to editing your application.
 
 This concludes this set of tutorials that introduce Enterprise Developer.
+
+> **Note**: You should re-enable Enterprise Server security if you have not already done so. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
 
 [Back to Top](#overview)

--- a/tutorial/gettingstarted/eclipseux/readme.md
+++ b/tutorial/gettingstarted/eclipseux/readme.md
@@ -60,9 +60,9 @@ In this release, the Enterprise Server security features are enabled by default.
 
 > **Important**: Micro Focus does not recommend disabling Enterprise Server security permanently. If you disable the default Enterprise Server security to facilitate running tutorials then this should be performed on a network isolated machine. Re-enable security as soon as possible after completing the tutorial. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
 
-1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd` (Windows) or `DisableESDefaultSecurity.sh` (UNIX). You will see a series of messages as the script disables default security.
+1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.sh`. You will see a series of messages as the script disables default security.
 2. Restart MFDS and ESCWA to pick up the configuration changes. You will now be able to use ESCWA without having to log in.
-3. Restart any running enterprise server region to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
+3. Restart any running enterprise server regions to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
 
 ## Starting the Eclipse Integrated Development Environment (IDE)
 

--- a/tutorial/gettingstarted/eclipseux/readme.md
+++ b/tutorial/gettingstarted/eclipseux/readme.md
@@ -97,6 +97,21 @@ In this release, the Enterprise Server security features are enabled by default.
 2.  If you close a view, click **Window** \> **Show View** \> **View Name** to restore it.
 3.  At any time, you can reset the complete layout of the Team Developer Perspective to its default using **Window \> Perspective \> Reset Perspective**.
 
+### Connect to the default ESCWA server
+
+Ensure that **Server Explorer** contains a connection to the default Enterprise Server Common Web Administration (ESCWA) server. Note that existing workspaces may already have this connection.
+
+1. In the **Server Explorer** view, right-click and select **New > Enterprise Server Common Web Administration Connection**.
+
+    The **New Enterprise Server Common Web Administration Connection** dialog box is displayed.
+2. In the **Name** field, type **Local**.
+3. In the **Server address** field, type **localhost**.
+4. In the **Server port** field, leave as the default 10086.
+5. If the server connection is TLS-enabled, select **TLS Enabled**, and then click **Browse** and select the appropriate certificate.
+>**Note**: If **TLS Enabled** is selected, but you do not specify a certificate, the default Java keystore is searched for a valid one.
+6. Click **Finish**.
+The new ESCWA connection is displayed at the top level, in the **Server Explorer**.
+
 ## Creating a Project and Adding the Source Files
 
 [Back to Top](#overview)

--- a/tutorial/gettingstarted/visualstudio/PLIDemo.md
+++ b/tutorial/gettingstarted/visualstudio/PLIDemo.md
@@ -30,6 +30,16 @@ If you have already imported the BANKDEMO enterprise server as part of the "[Get
     
    The BANKDEMO server should appear in Server Explorer under **Local**.
 
+### Disable the default Enterprise Server security configuration
+
+In this release, the Enterprise Server security features are enabled by default. Tutorials that use enterprise server regions, however, assume that Enterprise Server security is not configured. To perform this tutorial without modification, you must disable the default configured Enterprise Server security. See *To Disable the Default Enterprise Server Security Configuration* for more information.
+
+> **Important**: Micro Focus does not recommend disabling Enterprise Server security permanently. If you disable the default Enterprise Server security to facilitate running tutorials then this should be performed on a network isolated machine. Re-enable security as soon as possible after completing the tutorial. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
+
+1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd` (Windows) or `DisableESDefaultSecurity.sh` (UNIX). You will see a series of messages as the script disables default security.
+2. Restart MFDS and ESCWA to pick up the configuration changes. You will now be able to use ESCWA without having to log in.
+3. Restart any running enterprise server region to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
+
 
 ### Configure the BANKDEMO enterprise server for PL/I:
     
@@ -95,3 +105,5 @@ Now that you have finished running the CICS demo, you can stop the associated th
  
 1.  In Server Explorer, right-click the **BANKDEMO** server, and click **Stop**.
 2.  Check the **Output** window for messages that the server has been stopped. A number of messages also appear in the **Enterprise Server Console Daemon** window outside of Visual Studio before it closes down.
+
+> **Note**: You should re-enable Enterprise Server security if you have not already done so. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 

--- a/tutorial/gettingstarted/visualstudio/PLIDemo.md
+++ b/tutorial/gettingstarted/visualstudio/PLIDemo.md
@@ -36,9 +36,9 @@ In this release, the Enterprise Server security features are enabled by default.
 
 > **Important**: Micro Focus does not recommend disabling Enterprise Server security permanently. If you disable the default Enterprise Server security to facilitate running tutorials then this should be performed on a network isolated machine. Re-enable security as soon as possible after completing the tutorial. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
 
-1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd` (Windows) or `DisableESDefaultSecurity.sh` (UNIX). You will see a series of messages as the script disables default security.
+1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd`. You will see a series of messages as the script disables default security.
 2. Restart MFDS and ESCWA to pick up the configuration changes. You will now be able to use ESCWA without having to log in.
-3. Restart any running enterprise server region to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
+3. Restart any running enterprise server regions to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
 
 
 ### Configure the BANKDEMO enterprise server for PL/I:

--- a/tutorial/gettingstarted/visualstudio/readme.md
+++ b/tutorial/gettingstarted/visualstudio/readme.md
@@ -51,6 +51,18 @@ A preconfigured, fully executing application, BankDemo, is available from the Mi
 
    We recommend that, if you want remote users to access Enterprise Server functionality through the firewall, you use fixed port values so that you can control access via these.
 
+## Enterprise Server security
+
+In this release, the Enterprise Server security features are enabled by default. Tutorials that use enterprise server regions, however, assume that Enterprise Server security is not configured. To perform this tutorial without modification, you must disable the default configured Enterprise Server security. See *To Disable the Default Enterprise Server Security Configuration* for more information.
+
+### Disable the default Enterprise Server security configuration
+
+> **Important**: Micro Focus does not recommend disabling Enterprise Server security permanently. If you disable the default Enterprise Server security to facilitate running tutorials then this should be performed on a network isolated machine. Re-enable security as soon as possible after completing the tutorial. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
+
+1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd` (Windows) or `DisableESDefaultSecurity.sh` (UNIX). You will see a series of messages as the script disables default security.
+2. Restart MFDS and ESCWA to pick up the configuration changes. You will now be able to use ESCWA without having to log in.
+3. Restart any running enterprise server region to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
+
 ## Starting the Visual Studio Integrated Development Environment
 
 [Back to Top](#overview)
@@ -1101,5 +1113,7 @@ Although the job has completed, the debugger is still waiting for the next event
 **1.** Click **Debug** \> **Stop Debugging**.
 
 This concludes this set of tutorials that introduce Micro Focus Enterprise Developer.
+
+> **Note**: You should re-enable Enterprise Server security if you have not already done so. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
 
 [Back to Top](#overview)

--- a/tutorial/gettingstarted/visualstudio/readme.md
+++ b/tutorial/gettingstarted/visualstudio/readme.md
@@ -59,9 +59,9 @@ In this release, the Enterprise Server security features are enabled by default.
 
 > **Important**: Micro Focus does not recommend disabling Enterprise Server security permanently. If you disable the default Enterprise Server security to facilitate running tutorials then this should be performed on a network isolated machine. Re-enable security as soon as possible after completing the tutorial. See *To recreate the Default Enterprise Server Security Configuration* in the product documentation for steps on how to re-enable security. 
 
-1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd` (Windows) or `DisableESDefaultSecurity.sh` (UNIX). You will see a series of messages as the script disables default security.
+1. In an Enterprise Developer command prompt, run the command `DisableESDefaultSecurity.cmd`. You will see a series of messages as the script disables default security.
 2. Restart MFDS and ESCWA to pick up the configuration changes. You will now be able to use ESCWA without having to log in.
-3. Restart any running enterprise server region to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
+3. Restart any running enterprise server regions to have them pick up the configuration changes. Regions will no longer require credentials for starting/stopping and other actions.
 
 ## Starting the Visual Studio Integrated Development Environment
 


### PR DESCRIPTION
- Add steps to disable ES security for tutorials. 
- Reminder at end of each tutorial to re-enable security. 
- Minor typo fixes.