### PR TITLE
Fix deployment of PAC on premises demonstration

### DIFF
--- a/scripts/MF_Provision_Region.py
+++ b/scripts/MF_Provision_Region.py
@@ -185,7 +185,7 @@ def create_region(main_configfile):
                 write_log('ERROR: PostgreSQL ODBC driver not found')
                 sys.exit(1)
  
-    #determine te individual component configuration files to be used
+    #determine the individual component configuration files to be used
     configuration_files = main_config["configuration_files"]
 
     #base_config is used for settings to create the base region definition

--- a/scripts/MF_Provision_Region.py
+++ b/scripts/MF_Provision_Region.py
@@ -257,8 +257,7 @@ def create_region(main_configfile):
             dfhdrdat = os.path.join(rdef, 'dfhdrdat')
             shutil.chown(dfhdrdat, esuid, esuid)
             write_log ('Set owner of {} to {}'.format(dfhdrdat, esuid))
-            create_db_vault_secrets(os_type, main_config, esuid)
-
+        create_db_vault_secrets(os_type, main_config, esuid)
     
     base_config = os.path.join(config_dir, base_config)
     update_config = os.path.join(config_dir, update_config)

--- a/scripts/database/odbc.py
+++ b/scripts/database/odbc.py
@@ -26,9 +26,9 @@ def check_odbc_driver_installed(db_type):
     if db_type != 'postgres':
         write_log("check_odbc_driver: invalid db_type {}".format(db_type))
         sys.exit(1)
-    driver_name = subprocess.getoutput("odbcinst -q -d | grep ANSI | grep PostgreSQL | sed 's/\[//g;s/\]//g'")
+    driver_name = subprocess.getoutput("odbcinst -q -d | grep ANSI | grep PostgreSQL | sed 's/\\[//g;s/\\]//g'")
     if driver_name=='':
-        driver_name = subprocess.getoutput("odbcinst -q -d | grep PostgreSQL | sed 's/\[//g;s/\]//g'")
+        driver_name = subprocess.getoutput("odbcinst -q -d | grep PostgreSQL | sed 's/\\[//g;s/\\]//g'")
     if driver_name[0:10] != 'PostgreSQL':
         write_log("check_odbc_driver: unable to find ODBC driver, running odbcinst -q -d")
         return False
@@ -40,9 +40,9 @@ def create_linux_dsn(db_type, dsn_name, description, database_name, database_con
     if db_type != 'postgres':
         write_log("create_linux_dsn: invalid db_type {}".format(db_type))
         sys.exit(1)
-    driver_name = subprocess.getoutput("odbcinst -q -d | grep ANSI | grep PostgreSQL | sed 's/\[//g;s/\]//g'")
+    driver_name = subprocess.getoutput("odbcinst -q -d | grep ANSI | grep PostgreSQL | sed 's/\\[//g;s/\\]//g'")
     if driver_name=='':
-        driver_name = subprocess.getoutput("odbcinst -q -d | grep PostgreSQL | sed 's/\[//g;s/\]//g'")
+        driver_name = subprocess.getoutput("odbcinst -q -d | grep PostgreSQL | sed 's/\\[//g;s/\\]//g'")
     if driver_name=='':
         write_log("create_linux_dsn: unable to find PostgreSQL ODBC driver\nSee 'odbcinst -q -d'")
         sys.exit(1)

--- a/scripts/utilities/deploy.py
+++ b/scripts/utilities/deploy.py
@@ -139,7 +139,7 @@ def deploy_vsam_postgres_pac(session, os_type, main_config, cwd, mfdbfh_config, 
     configure_xa(session, os_type, main_config, cwd, esuid)
     update_region_attribute(session, region_name, {"mfCASTXFILEP": "sql://BankPAC/VSAM?type=folder;folder=/data"})
 
-    create_db_vault_secrets(os_type, main_config, esuid)
+    catalog_pac_datasets(session, os_type, main_config, cwd, mfdbfh_config, esuid)
 
     write_log ('out of deploy_vsam_postgres_pac')
 


### PR DESCRIPTION
Ensure vault secrets are setup for Windows as well as Linux before being accessed for the first time
Ensure VSAM datasets are deployed into DBFH datastore
Correct Python string escaping to fix warning message (finding ODBC driver name on Linux)